### PR TITLE
PHP 8.3 optional parameter error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
         strategy:
             matrix:
                 include:
+                    - php: 8.3
                     - php: 8.2
                     - php: 8.1
 

--- a/src/Entity/EmailAddress.php
+++ b/src/Entity/EmailAddress.php
@@ -8,8 +8,8 @@ class EmailAddress
         readonly string $address,
         readonly string $local,
         readonly string $delivery,
-        readonly string|null $tag = null,
-        readonly string $domain,
+        readonly ?string $tag = null,
+        readonly ?string $domain = null,
     ) {
         # code...
     }


### PR DESCRIPTION
Fixes the error "deprecate required parameters after optional parameters in function" in PHP 8.3.